### PR TITLE
fix index quote timestamp parsing issue

### DIFF
--- a/lib/ticker.js
+++ b/lib/ticker.js
@@ -542,7 +542,7 @@ var KiteTicker = function(params) {
                 if (bin.byteLength === 32) {
 					tick.timestamp = null;
 					var timestamp = buf2long(bin.slice(28, 32));
-					if (timestamp) tick.timestamp = new Date(timestamp);
+					if (timestamp) tick.timestamp = new Date(timestamp * 1000);
 				}
 
 				ticks.push(tick);


### PR DESCRIPTION
The timestamp in the index quote needs to be multiplied by 1000 for correct Date parsing. This is being done for the full quote timestamp but not for the index quote.